### PR TITLE
Enable GL_ARB_explicit_attrib_location with OpenGL versions 2.1-3.2

### DIFF
--- a/src/pipeline/compatibility.rs
+++ b/src/pipeline/compatibility.rs
@@ -355,7 +355,7 @@ unsafe fn create_program(
         match (version.major, version.minor, version.is_embedded) {
             // OpenGL 3.0+
             (3, 0 | 1 | 2, false) => (
-                format!("#version 1{}0\n#extension GL_ARB_explicit_attrib_location : enable", version.minor + 3),
+                format!("#version 1{}0", version.minor + 3),
                 format!(
                     "#version 1{}0\n#define HIGHER_THAN_300 1",
                     version.minor + 3
@@ -387,7 +387,7 @@ unsafe fn create_program(
             // OpenGL 2.1
             (2, _, false) => (
                 String::from(
-                    "#version 120\n#define in attribute\n#define out varying\n#extension GL_ARB_explicit_attrib_location : enable",
+                    "#version 120\n#define in attribute\n#define out varying",
                 ),
                 String::from("#version 120\n#define in varying"),
             ),

--- a/src/pipeline/compatibility.rs
+++ b/src/pipeline/compatibility.rs
@@ -355,7 +355,7 @@ unsafe fn create_program(
         match (version.major, version.minor, version.is_embedded) {
             // OpenGL 3.0+
             (3, 0 | 1 | 2, false) => (
-                format!("#version 1{}0", version.minor + 3),
+                format!("#version 1{}0\n#extension GL_ARB_explicit_attrib_location : enable", version.minor + 3),
                 format!(
                     "#version 1{}0\n#define HIGHER_THAN_300 1",
                     version.minor + 3
@@ -387,7 +387,7 @@ unsafe fn create_program(
             // OpenGL 2.1
             (2, _, false) => (
                 String::from(
-                    "#version 120\n#define in attribute\n#define out varying",
+                    "#version 120\n#define in attribute\n#define out varying\n#extension GL_ARB_explicit_attrib_location : enable",
                 ),
                 String::from("#version 120\n#define in varying"),
             ),

--- a/src/pipeline/core.rs
+++ b/src/pipeline/core.rs
@@ -290,7 +290,7 @@ unsafe fn create_program(
         match (version.major, version.minor, version.is_embedded) {
             // OpenGL 3.0+
             (3, 0 | 1 | 2, false) => (
-                format!("#version 1{}0", version.minor + 3),
+                format!("#version 1{}0\n#extension GL_ARB_explicit_attrib_location : enable", version.minor + 3),
                 format!(
                     "#version 1{}0\n#define HIGHER_THAN_300 1",
                     version.minor + 3
@@ -322,7 +322,7 @@ unsafe fn create_program(
             // OpenGL 2.1
             (2, _, false) => (
                 String::from(
-                    "#version 120\n#define in attribute\n#define out varying",
+                    "#version 120\n#define in attribute\n#define out varying\n#extension GL_ARB_explicit_attrib_location : enable",
                 ),
                 String::from("#version 120\n#define in varying"),
             ),


### PR DESCRIPTION
This PR aims to resolve issue #6.

Three [OctaSine](https://github.com/greatest-ape/OctaSine) users have reported that it fixes crashes.

Panic without the fix on Linux with NVIDIA graphics:

![glow-glyph-crash](https://user-images.githubusercontent.com/17945069/167026339-085b52de-7a0c-433b-be30-a56402b7fee5.png)

Panic without the fix on Windows 11 with AMD graphics:

```
08:17:31 [INFO] Version: 3.2.14800, Core Profile Context 22.3.1 30.0.15002.1004
08:17:31 [INFO] Embedded: false
08:17:31 [INFO] Renderer: AMD Radeon RX 6800 XT
08:17:31 [INFO] Mode: core
08:17:31 [INFO] Shader directive: #version 150
thread 'main' panicked at 'Vertex shader failed to compile with the following errors:
ERROR: 0:4: error(#5) Extension: "explicit location is not supported in this version"
ERROR: 0:5: error(#5) Extension: "explicit location is not supported in this version"
ERROR: 0:6: error(#5) Extension: "explicit location is not supported in this version"
ERROR: 0:7: error(#5) Extension: "explicit location is not supported in this version"
ERROR: 0:8: error(#5) Extension: "explicit location is not supported in this version"
ERROR: error(#273) 5 compilation errors.  No code generated
```