### PR TITLE
Update `glow` to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/glow_glyph"
 readme = "README.md"
 
 [dependencies]
-glow = "0.11.1"
+glow = "0.12.0"
 glyph_brush = "0.7"
 log = "0.4"
 bytemuck = "1.4"


### PR DESCRIPTION
A prerequisite for updating the dependency in `iced_glow`.